### PR TITLE
[refs #00073] Add copyright holder to Customizer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -32,7 +32,17 @@
 			  )
 			); 
 			?>
-			<p class="c-page-footer__smallprint"><small>Copyright © <?php echo get_bloginfo( 'name' ) ." ". date('Y'); ?>. All rights reserved.</small></p>
+			<p class="c-page-footer__smallprint"><small>Copyright © 
+				<?php if (get_theme_mod('copyright')) {
+					// Display copyright holder, if set
+					echo get_theme_mod('copyright');
+				}
+				else {
+					// Otherwise, display site title as copyright holder
+					echo get_bloginfo( 'name' );
+				}
+				echo " ". date('Y')."."; ?>
+				All rights reserved.</small></p>
 		</div>
 	</footer>
 </div><!-- #page -->

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -50,6 +50,20 @@ function nightingale_wp_customize_register( $wp_customize ) {
 		'type'      => 'checkbox',
 	) ) );
 
+	// Add "Copyright" setting within "Theme Settings" section (see above)
+	$wp_customize->add_setting( 'copyright' , array(
+    'default'     => get_bloginfo( 'name' ),
+    'transport'   => 'refresh',
+	) );
+
+	// Add "Breadcrumbs" control within "Theme Settings" setting (see above)
+	$wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'copyright', array(
+		'label'        => 'Copyright Holder:',
+		'section'    => 'theme_settings',
+		'settings'   => 'copyright',
+		'type'      => 'text',
+	) ) );
+
 }
 add_action( 'customize_register', 'nightingale_wp_customize_register' );
 


### PR DESCRIPTION
Allow users to override default copyright holder (taken from site title)
displayed in footer.