### PR TITLE
[refs #00096] Add 'jsPage' and 'no-js' to header

### DIFF
--- a/header.php
+++ b/header.php
@@ -10,7 +10,7 @@
  */
 
 ?><!DOCTYPE html>
-<html <?php language_attributes(); ?>>
+<html <?php language_attributes(); ?> id="jsPage" class="no-js">
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1.0">


### PR DESCRIPTION
To fix JavaScript errors, add id="jsPage" and class="no-js" to header. Not sure why this wasn't there before, nor why it hasn't cropped up as a problem before.