### PR TITLE
[refs #00099] Put metadata above posts

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -31,6 +31,13 @@ $global-hints: true;
 @import "nightingale/main.scss";
 
 /**
+ * Make sure posts are _below_ metadata (author and date)
+ */
+.entry-content {
+    clear: both;
+}
+
+/**
  * Override Nightingale’s default nav alignment (until issue #146 is addressed).
  */
 .c-nav-primary__item {


### PR DESCRIPTION
Make sure metadata (e.g. author, date, etc.) are above post body.

From this:
![screen shot 2018-01-30 at 15 30 15](https://user-images.githubusercontent.com/1991226/35616726-09048c6c-066e-11e8-8840-3381db9c5eec.png)

To this:
![screen shot 2018-01-31 at 10 03 32](https://user-images.githubusercontent.com/1991226/35616747-16bd58fc-066e-11e8-9b5d-90273eab3cf5.png)
