### PR TITLE
Tkt 00103 - post listing styling

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -12,7 +12,7 @@ get_header(); ?>
 
 	<!-- reduce width of primary content if sidebar contains widgets -->
 	<div id="primary" class="o-layout__item u-8/12@lg">
-		
+
 		<main id="main" class="site-main" role="main">
 
 		<?php
@@ -40,12 +40,11 @@ get_header(); ?>
 				 */
 
 				 // Display horizontal rule above all but the first post
-				 if ( $first_post == false ) { 
+				 if ( $first_post == false ) {
 					 echo '<hr class="c-divider">';
 				 }
 				 $first_post = false;
-
-				 get_template_part( 'template-parts/content', get_post_format() );
+				 get_template_part( 'template-parts/content', get_theme_mod('post-listing') );
 
 			endwhile;
 

--- a/archive.php
+++ b/archive.php
@@ -16,13 +16,17 @@ get_header(); ?>
 		<main id="main" class="site-main" role="main">
 
 		<?php
-		if ( have_posts() ) : ?>
+		if ( have_posts() ) :
 
+			// Initialise variable to tag first post in loop
+			$first_post = true;
+			?>
 			<header class="page-header">
 				<?php
 					the_archive_title( '<h1 class="page-title">', '</h1>' );
 					the_archive_description( '<div class="archive-description">', '</div>' );
 				?>
+				<hr class="c-divider">
 			</header><!-- .page-header -->
 
 			<?php
@@ -34,7 +38,14 @@ get_header(); ?>
 				 * If you want to override this in a child theme, then include a file
 				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 				 */
-				get_template_part( 'template-parts/content', get_post_format() );
+
+				 // Display horizontal rule above all but the first post
+				 if ( $first_post == false ) { 
+					 echo '<hr class="c-divider">';
+				 }
+				 $first_post = false;
+
+				 get_template_part( 'template-parts/content', get_post_format() );
 
 			endwhile;
 

--- a/home.php
+++ b/home.php
@@ -22,10 +22,15 @@ get_header(); ?>
 
 		<?php
 		if ( have_posts() ) :
-
+			
+			// Initialise variable to tag first post in loop
+			$first_post = true;
+			
+			// Display page header only if not on front page
 			if ( ! is_front_page() ) : ?>
 				<header>
 					<h1 class="page-title screen-reader-text"><?php single_post_title(); ?></h1>
+					<hr class="c-divider">
 				</header>
 
 			<?php
@@ -39,6 +44,13 @@ get_header(); ?>
 				 * If you want to override this in a child theme, then include a file
 				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 				 */
+				 
+				 // Display horizontal rule above all but the first post
+				 if ( $first_post == false ) { 
+					 echo '<hr class="c-divider">';
+				 }
+				 $first_post = false;
+				 
 				 // Use appropriate template-part depending on post listing style set in customizer
 				 switch (get_theme_mod('post-listing')) {
 						case 'titles':

--- a/home.php
+++ b/home.php
@@ -17,15 +17,15 @@ get_header(); ?>
 
 	<!-- reduce width of primary content if sidebar contains widgets -->
 	<div id="primary" class="o-layout__item u-8/12@lg">
-		
+
 		<main id="main" class="site-main" role="main">
 
 		<?php
 		if ( have_posts() ) :
-			
+
 			// Initialise variable to tag first post in loop
 			$first_post = true;
-			
+
 			// Display page header only if not on front page
 			if ( ! is_front_page() ) : ?>
 				<header>
@@ -44,29 +44,29 @@ get_header(); ?>
 				 * If you want to override this in a child theme, then include a file
 				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 				 */
-				 
+
 				 // Display horizontal rule above all but the first post
-				 if ( $first_post == false ) { 
+				 if ( $first_post == false ) {
 					 echo '<hr class="c-divider">';
 				 }
 				 $first_post = false;
-				 
+
 				 // Use appropriate template-part depending on post listing style set in customizer
 				 switch (get_theme_mod('post-listing')) {
-						case 'titles':
+						case 'title':
 							get_template_part( 'template-parts/content', 'title' );
 							break;
-						case 'excerpts':
+						case 'excerpt':
 							get_template_part( 'template-parts/content', 'excerpt' );
 							break;
 						default:
 							get_template_part( 'template-parts/content', get_post_format() );
 				 }
-				
+
 			endwhile;
 
 			nightingale_pagination();
-			
+
 		else :
 
 			get_template_part( 'template-parts/content', 'none' );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -70,8 +70,8 @@ function nightingale_wp_customize_register( $wp_customize ) {
 		'type'      => 'select',
 		'choices'  => array(
 			'full'  => __('Display FULL posts', 'nightingale-wp'),
-			'excerpts' => __('Display post EXCERPTS', 'nightingale-wp'),
-			'titles' => __('Display post TITLES only', 'nightingale-wp'),
+			'excerpt' => __('Display post EXCERPTS', 'nightingale-wp'),
+			'title' => __('Display post TITLES only', 'nightingale-wp'),
 		) ) ) );
 
 	// Add "Copyright" setting within "Theme Settings" section (see above)

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -34,20 +34,20 @@ if ( ! function_exists( 'nightingale_wp_entry_footer' ) ) :
  * Prints HTML with meta information for the categories, tags and comments.
  */
 function nightingale_wp_entry_footer() {
-	
+
 	?>
 	<div class="o-layout">
 		<div class="o-layout__item u-9/12@lg">
 			<div class="o-layout--left">
 				<?php
 				if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
-					if (get_theme_mod('post-listing') != 'titles') {
+					if (get_theme_mod('post-listing') != 'title') {
 						// Don't show comments link for posts listed as titles only
-						/* translators: %s: post title */		
+						/* translators: %s: post title */
 						comments_popup_link( sprintf( wp_kses( __( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'nightingale-wp' ), array( 'span' => array( 'class' => array() ) ) ), get_the_title() ) );
 					}
 				}
-				?>	
+				?>
 			</div><!--o-layout--left-->
 		</div><!--o-layout__item-->
 		<div class="o-layout__item  u-3/12@lg">
@@ -65,7 +65,7 @@ function nightingale_wp_entry_footer() {
 		</div><!--o-layout__item-->
 	</div><!--o-layout-->
 	<?php
-	
+
 	if (get_theme_mod('post-listing') != 'titles') {
 		// Don't show edit link for posts listed as titles only
 		edit_post_link(
@@ -78,7 +78,7 @@ function nightingale_wp_entry_footer() {
 			'</span>'
 		);
 	}
-	
+
 }
 endif;
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -12,27 +12,19 @@ if ( ! function_exists( 'nightingale_wp_posted_on' ) ) :
  * Prints HTML with meta information for the current post-date/time and author.
  */
 function nightingale_wp_posted_on() {
-	$time_string = '<time class="entry-date" datetime="%1$s">%2$s</time>';
-	if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-		$time_string = '<time class="entry-date" datetime="%1$s">%2$s</time>';
-	}
 
-	$time_string = sprintf( $time_string,
-		esc_attr( get_the_date( 'c' ) ),
-		esc_html( get_the_date() )
-	);
-
-	$posted_on = sprintf(
-		esc_html_x( '%s', 'post date', 'nightingale-wp' ),
-		'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
-	);
-
-	$byline = sprintf(
-		esc_html_x( '%s', 'post author', 'nightingale-wp' ),
-		'<span class="author vcard"><a class="c-comment__author url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
-	);
-
-	echo '<span class="byline"> ' . $byline . '</span><span class="c-comment__date">' . $time_string . '</span>'; // WPCS: XSS OK.
+	echo '<div class="o-layout">
+		<div class="o-layout__item u-9/12@lg">
+			<div class="o-layout--left">
+				<a class="c-comment__author" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a>
+			</div><!--o-layout--left-->
+		</div><!--o-layout__item-->
+		<div class="o-layout__item  u-3/12@lg">
+			<div class="o-layout--right">
+				<a class="c-comment__date" href="' . esc_url( get_day_link( get_the_time( "Y" ), get_the_time( "m" ), get_the_time( "d" ) ) ) . '" rel="bookmark">' . get_the_time( "d/m/Y" ) . '</a>
+			</div><!--o-layout--right-->
+		</div><!--o-layout__item-->
+	</div><!--o-layout-->';
 
 }
 endif;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -66,7 +66,7 @@ function nightingale_wp_entry_footer() {
 	</div><!--o-layout-->
 	<?php
 
-	if (get_theme_mod('post-listing') != 'titles') {
+	if (get_theme_mod('post-listing') != 'title') {
 		// Don't show edit link for posts listed as titles only
 		edit_post_link(
 			sprintf(

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -55,7 +55,7 @@ function nightingale_wp_entry_footer() {
 				<?php
 				// Read more link
 				if ( is_home () || is_category() || is_archive() ) {
-					if (get_theme_mod('post-listing') == 'excerpts') {
+					if (get_theme_mod('post-listing') == 'excerpt') {
 						// Only show "read More" link for posts listed as excerpts
 						echo '<a href="'. get_permalink( get_the_ID() ) . '">' . __('Read More', 'nightingale-wp') . '</a>';
 					}

--- a/index.php
+++ b/index.php
@@ -16,7 +16,7 @@ get_header(); ?>
 <div class="o-layout  o-layout--wide">
 
 	<div id="primary" class="o-layout__item u-8/12@lg">
-		
+
 		<main id="main" class="site-main" role="main">
 
 		<?php
@@ -44,17 +44,17 @@ get_header(); ?>
 				 */
 
 				 // Display horizontal rule above all but the first post
-				 if ( $first_post == false ) { 
+				 if ( $first_post == false ) {
 					 echo '<hr class="c-divider">';
 				 }
 				 $first_post = false;
 
-				get_template_part( 'template-parts/content', get_post_format() );
+				get_template_part( 'template-parts/content', get_theme_mod('post-listing') );
 
 			endwhile;
 
 			nightingale_pagination();
-			
+
 		else :
 
 			get_template_part( 'template-parts/content', 'none' );

--- a/index.php
+++ b/index.php
@@ -22,9 +22,13 @@ get_header(); ?>
 		<?php
 		if ( have_posts() ) :
 
+			// Initialise variable to tag first post in loop
+			$first_post = true;
+
 			if ( is_home() && ! is_front_page() ) : ?>
 				<header>
 					<h1 class="page-title screen-reader-text"><?php single_post_title(); ?></h1>
+					<hr class="c-divider">
 				</header>
 
 			<?php
@@ -38,6 +42,13 @@ get_header(); ?>
 				 * If you want to override this in a child theme, then include a file
 				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 				 */
+
+				 // Display horizontal rule above all but the first post
+				 if ( $first_post == false ) { 
+					 echo '<hr class="c-divider">';
+				 }
+				 $first_post = false;
+
 				get_template_part( 'template-parts/content', get_post_format() );
 
 			endwhile;

--- a/template-parts/content-excerpt.php
+++ b/template-parts/content-excerpt.php
@@ -15,7 +15,6 @@
 		if ( is_single() ) :
 			the_title( '<h1>', '</h1>' );
 		else :
-			echo '<hr class="c-divider">';
 			the_title( '<h2 class="c-article__header"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 		endif;
 

--- a/template-parts/content-excerpt.php
+++ b/template-parts/content-excerpt.php
@@ -9,12 +9,13 @@
 
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?> class="c-article">
+<article class="c-article" id="post-<?php the_ID(); ?>">
 	<header>
 		<?php
 		if ( is_single() ) :
 			the_title( '<h1>', '</h1>' );
 		else :
+			echo '<hr class="c-divider">';
 			the_title( '<h2 class="c-article__header"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 		endif;
 
@@ -24,7 +25,7 @@
 		endif; ?>
 	</header>
 
-	<div class="entry-content">
+	<div class="c-article__content">
 		<?php
 			the_excerpt( sprintf(
 				/* translators: %s: Name of current post. */
@@ -36,9 +37,9 @@
 				'after'  => '</div>',
 			) );
 		?>
-	</div><!-- .entry-content -->
+	</div><!-- .c-article__content -->
 
-	<footer class="entry-footer">
+	<footer>
 		<?php nightingale_wp_entry_footer(); ?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-## -->

--- a/template-parts/content-excerpt.php
+++ b/template-parts/content-excerpt.php
@@ -9,24 +9,20 @@
 
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<header class="entry-header">
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?> class="c-article">
+	<header>
 		<?php
 		if ( is_single() ) :
-			the_title( '<h1 class="entry-title">', '</h1>' );
+			the_title( '<h1>', '</h1>' );
 		else :
-			the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+			the_title( '<h2 class="c-article__header"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 		endif;
 
-		if ( 'post' === get_post_type() ) : ?>
-		<div class="entry-meta">
-			<?php
+		if ( 'post' === get_post_type() ) :
+			// Display post author and date
 			nightingale_wp_posted_on();
-			?>
-		</div><!-- .entry-meta -->
-		<?php
 		endif; ?>
-	</header><!-- .entry-header -->
+	</header>
 
 	<div class="entry-content">
 		<?php

--- a/template-parts/content-title.php
+++ b/template-parts/content-title.php
@@ -9,18 +9,16 @@
 
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<header class="entry-header">
+<article class="c-article" id="post-<?php the_ID(); ?>">
+	<header>
 		<?php
 		if ( is_single() ) :
-			the_title( '<h1 class="entry-title">', '</h1>' );
+			the_title( '<h1>', '</h1>' );
 		else :
-			the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+			the_title( '<h2 class="c-article__header"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 		endif;
 
-		if ( 'post' === get_post_type() ) : ?>
-		<div class="entry-meta">
-			<?php
+		if ( 'post' === get_post_type() ) :
 			// Display category list
 			echo the_category(' | ', get_the_ID());
 			// Display tag(s)
@@ -30,22 +28,19 @@
 					echo " | <a href='/tag/$tag->slug'>" . $tag->name . '</a>'; 
 				}
 			}
-			?>
-		</div><!-- .entry-meta -->
-		<?php
 		endif; ?>
-	</header><!-- .entry-header -->
+	</header>
 
-	<div class="entry-content">
-		<?php		
+	<div class="c-article__content">
+		<?php
 			wp_link_pages( array(
 				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'nightingale-wp' ),
 				'after'  => '</div>',
 			) );
 		?>
-	</div><!-- .entry-content -->
+	</div><!-- .c-article__content -->
 
-	<footer class="entry-footer">
+	<footer>
 		<?php nightingale_wp_entry_footer(); ?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-## -->

--- a/template-parts/content-title.php
+++ b/template-parts/content-title.php
@@ -15,17 +15,19 @@
 		if ( is_single() ) :
 			the_title( '<h1>', '</h1>' );
 		else :
-			the_title( '<h2 class="c-article__header"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+			the_title( '<h2 class="c-article__header--titles-only"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 		endif;
 
 		if ( 'post' === get_post_type() ) :
+			// Display post author and date
+			nightingale_wp_posted_on();
 			// Display category list
 			echo the_category(' | ', get_the_ID());
 			// Display tag(s)
 			$posttags = get_the_tags();
 			if ($posttags) {
 				foreach($posttags as $tag) {
-					echo " | <a href='/tag/$tag->slug'>" . $tag->name . '</a>'; 
+					echo " | <a href='/tag/$tag->slug'>" . $tag->name . '</a>';
 				}
 			}
 		endif; ?>

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -9,26 +9,22 @@
 
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<header class="entry-header">
+<article class="c-article" id="post-<?php the_ID(); ?>">
+	<header>
 		<?php
 		if ( is_single() ) :
-			the_title( '<h1 class="entry-title">', '</h1>' );
+			the_title( '<h1>', '</h1>' );
 		else :
-			the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+			the_title( '<h2 class="c-article__header"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 		endif;
 
-		if ( 'post' === get_post_type() ) : ?>
-		<div class="entry-meta">
-			<?php
+		if ( 'post' === get_post_type() ) :
+			// Display post author and date
 			nightingale_wp_posted_on();
-			?>
-		</div><!-- .entry-meta -->
-		<?php
 		endif; ?>
-	</header><!-- .entry-header -->
+	</header>
 
-	<div class="entry-content">
+	<div class="c-article__content">
 		<?php
 			the_content( sprintf(
 				/* translators: %s: Name of current post. */
@@ -40,9 +36,9 @@
 				'after'  => '</div>',
 			) );
 		?>
-	</div><!-- .entry-content -->
+	</div><!-- .c-article__content -->
 
-	<footer class="entry-footer">
+	<footer>
 		<?php nightingale_wp_entry_footer(); ?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-## -->


### PR DESCRIPTION
Apply nightingale styling to post listing and archive pages, whether posts are shown in full, as excerpts, or titles only. Apart from using the same markup as nightingale, the challenge here was to make sure posts are separated by horizontal rules, but without any extra ones appearing. And to make sure the page title, if present, is followed by a horizontal rule.

The screenshot below shows excerpts as they are listed on the home page (without a page title):

![screen shot 2018-02-06 at 11 21 39](https://user-images.githubusercontent.com/1991226/35857109-05c766fc-0b30-11e8-8340-919186a9da5c.png)

This screenshot shows full posts listed on a separate page (not the home page):

![screen shot 2018-02-06 at 11 24 24](https://user-images.githubusercontent.com/1991226/35857258-77d69dda-0b30-11e8-9226-888a53d1c12b.png)
