### PR TITLE
[refs #00125] Check parent page template

### DIFF
--- a/template-parts/content-tabs.php
+++ b/template-parts/content-tabs.php
@@ -28,7 +28,9 @@
 		 // Start first "Overview" link to parent page
 		 $link = '<li class="c-tabs__item"><a class="c-tabs__link';
 
-		 if( empty($post->post_parent) ) {
+		 // Only show siblings if current page has no parent or parent doesn't have tabbed navigation
+		 $parent_template = get_post_meta($post->post_parent, '_wp_page_template', true);
+		 if( empty($post->post_parent) || ($parent_template!='page-tabbed.php') ) {
 			 // On first arrival at the parent page, the Overview link is current (and therefore inactive)
 			 // and all the other links are to child pages...
 			 $link .= ' is-current';


### PR DESCRIPTION
To fix the error of sibling pages being shown in tabs when they shouldn't, only show siblings if the parent page doesn't use the tabbed navigation template.

Parent page:
![screen shot 2018-05-01 at 13 05 31](https://user-images.githubusercontent.com/1991226/39472316-71956f58-4d40-11e8-996c-a0288eb6d695.png)

Child page:
![screen shot 2018-05-01 at 13 04 55](https://user-images.githubusercontent.com/1991226/39472320-7c5188b4-4d40-11e8-9a46-a7c8c4da05fc.png)

Sibling page:
![screen shot 2018-05-01 at 13 05 16](https://user-images.githubusercontent.com/1991226/39472317-76aefa68-4d40-11e8-9f70-de93b70ebe94.png)