### PR TITLE
[refs #00127] Format homepage links

### DIFF
--- a/template-parts/acf-links.php
+++ b/template-parts/acf-links.php
@@ -4,14 +4,18 @@ if ( is_plugin_active( 'advanced-custom-fields-pro/acf.php' ) ) {
     //Check that the ACF plugin is activated
 
 	if( have_rows('links') ):
+
+		echo '<hr class="c-divider"><div class="o-layout  o-layout--wide">';
+
 	     // loop through the rows of data
 	    while ( have_rows('links') ) : the_row();
 
-	        the_sub_field('url');
-	        the_sub_field('title');
-	        the_sub_field('description');
+					echo '<div class="o-layout__item  u-4/12@lg"><h3><a href="' . get_sub_field('url') . '">' . get_sub_field('title') . '</a></h3>';
+					echo '<p>' . get_sub_field('description') . '</p></div><!-- o-layout__item -->';
 
 	    endwhile;
+
+		echo '</div><hr class="c-divider">';
 
 	else :
 


### PR DESCRIPTION
Display links from ACF on home page in three columns as shown below:

![screen shot 2018-05-02 at 15 55 15](https://user-images.githubusercontent.com/1991226/39530601-3f4c5cd2-4e21-11e8-9ce0-cd9c7eefef06.png)
