### PR TITLE
[refs #00128] Add CTA cards

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -34,11 +34,12 @@ get_header(); ?>
 
 		</main><!-- #main -->
 	</div><!-- #primary -->
-<?php get_template_part( 'template-parts/content', 'secondary' ) ?>	
+<?php get_template_part( 'template-parts/content', 'secondary' ) ?>
 <?php get_sidebar(); ?>
 </div><!-- .o-layout -->
 
 <?php get_template_part( 'template-parts/acf', 'links' );?>
+<?php get_template_part( 'template-parts/acf', 'cta-cards' );?>
 
 <?php
 get_footer();

--- a/template-parts/acf-cta-cards.php
+++ b/template-parts/acf-cta-cards.php
@@ -1,0 +1,32 @@
+<?php
+// check that the ACF plugin is activated
+include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+if ( is_plugin_active( 'advanced-custom-fields-pro/acf.php' ) ) {
+
+		if( have_rows('cards') ):
+
+				echo '<hr class="c-divider">
+				<div class="o-layout  o-layout--wide">';
+
+				// loop through the rows of data
+				while ( have_rows('cards') ) : the_row();
+						echo '<div class="o-layout__item  u-4/12@lg">
+								<div class="c-card  c-card--information">
+										<h4>' . get_sub_field('title') . '</h4>
+										<small>' . get_sub_field('text') . '</small>';
+										while ( have_rows('button') ) : the_row();
+												get_template_part( 'template-parts/acf', 'button' );
+										endwhile;
+								echo '</div><!-- c-card -->
+						</div><!-- o-layout__item -->';
+				endwhile;
+
+				echo '</div><!-- o-layout -->';
+
+	else :
+
+	    // no layouts found
+
+	endif;
+}
+?>


### PR DESCRIPTION
Use ACF to add Call To Action cards.

With current Nightingale version, they come out like this:

![screen shot 2018-05-11 at 17 43 45](https://user-images.githubusercontent.com/1991226/39936062-354b0746-5543-11e8-9209-5f17a248ac67.png)

But [this PR](https://github.com/NHSLeadership/nightingale/pull/230) applies the correct styling.
