### PR TITLE
Tkt-00158 - distorted images on post excerpts

### DIFF
--- a/template-parts/content-excerpt.php
+++ b/template-parts/content-excerpt.php
@@ -32,9 +32,7 @@
 			if ($post_thumbnail_id) {
 				$post_thumbnail_url = wp_get_attachment_url( $post_thumbnail_id );
 				?>
-				<div class="post-image">
-					<img title="<?php the_title(); ?>" alt="thumb image" class="c-media__media" src="<?php echo $post_thumbnail_url; ?>" style="width:100%; height:auto;">
-				</div>
+				<img title="<?php the_title(); ?>" alt="thumb image" class="c-media__media" src="<?php echo $post_thumbnail_url; ?>" style="width:100%; height:auto;">
 				<?php
 			}
 

--- a/template-parts/content-excerpt.php
+++ b/template-parts/content-excerpt.php
@@ -27,8 +27,16 @@
 	<div class="c-article__content">
 		<?php
 
-			// Display featured image
-			the_post_thumbnail('medium', ['class' => 'c-media__media']);
+			// Display featured image, if present, at 100% width
+			$post_thumbnail_id = get_post_thumbnail_id();
+			if ($post_thumbnail_id) {
+				$post_thumbnail_url = wp_get_attachment_url( $post_thumbnail_id );
+				?>
+				<div class="post-image">
+					<img title="<?php the_title(); ?>" alt="thumb image" class="c-media__media" src="<?php echo $post_thumbnail_url; ?>" style="width:100%; height:auto;">
+				</div>
+				<?php
+			}
 
 			the_excerpt( sprintf(
 				/* translators: %s: Name of current post. */


### PR DESCRIPTION
Fixed this. Excerpt images now look like this:

![screen shot 2018-05-23 at 09 58 44](https://user-images.githubusercontent.com/1991226/40414406-052097bc-5e70-11e8-9c0e-3b03fb3da031.png)
