### PR TITLE
[refs #00183] Order tabs by menu order

### DIFF
--- a/template-parts/content-tabs.php
+++ b/template-parts/content-tabs.php
@@ -54,6 +54,7 @@
 		 $args = array(
 			 'post_type' => 'page',
 			 'post_parent' => $post_parent,
+			 'orderby' => 'menu_order',
 			 'order' => 'ASC',
 			 'depth' => 1,
 			 'post_status' => 'publish',


### PR DESCRIPTION
Use menu order to display tabbed child pages in the order required by admins.

See https://github.com/NHSLeadership/nhsl-wp-corporate/issues/60 for more detail.