### PR TITLE
[refs #00187] Add secondary content to home page

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -29,6 +29,7 @@ get_header(); ?>
 
 		</main><!-- #main -->
 	</div><!-- #primary -->
+	<?php get_template_part( 'template-parts/content', 'secondary' ) ?>
 	<?php get_sidebar(); ?>
 
 </div><!-- .o-layout -->


### PR DESCRIPTION
James discovered that ACF secondary content was not showing on the home page. This fixes that issue.