### PR TITLE
[refs #00189] Hide fallback elements

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -62,3 +62,8 @@ a {
 
 /* WordPress generated classes */
 @import "style/wordpress";
+
+/* Styling for fallback elements */
+.fallback-only {
+   display: none;
+}


### PR DESCRIPTION
Used when displaying links as fallback with svg map.