### PR TITLE
[refs #00206] Safari bug fix

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -147,7 +147,7 @@ function nightingale_wp_scripts() {
 	wp_enqueue_script('nightingale-cookies');
 
 	// Yukky Safari bug fix
-	wp_register_script('nightingale-safari-bug-fix', get_template_directory_uri() . '/node_modules/nightingale/js/safari-bug-fix.js', array(), '1.1', true);
+	wp_register_script('nightingale-safari-bug-fix', get_template_directory_uri() . '/js/safari-bug-fix.js', array(), '1.1', true);
 	wp_enqueue_script('nightingale-safari-bug-fix');
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {

--- a/js/safari-bug-fix.js
+++ b/js/safari-bug-fix.js
@@ -1,0 +1,17 @@
+<script>
+	// Eww, eww, ewwww! Forcing a repaint to get around a really, really odd
+	// Safari bug: https://twitter.com/csswizardry/status/897110955448029184
+	(function(){
+		var ua = navigator.userAgent.toLowerCase();
+		if (ua.indexOf('safari') != -1) {
+			if (ua.indexOf('chrome') > -1) {
+			} else {
+				function ready() {
+					var page = document.getElementById('jsPage');
+					page.style.color = '#231f21';
+				};
+				document.addEventListener("DOMContentLoaded", ready);
+			}
+		}
+	}());
+</script>


### PR DESCRIPTION
Originally, this file was included in the Nightingale framework but, to increase performance, it was moved inline there. Whilst we could do the same here (put the script inline), I propose we keep it in a separate file and allow WordPress to enqueue it alongside all the other JavaScript and CSS files.