### PR TITLE
[refs #DI-1098] Fix links in reminder emails

### DIFF
--- a/inc/gravity-flow.php
+++ b/inc/gravity-flow.php
@@ -27,3 +27,8 @@ function sh_gravityflowformconnector_form_submission_token_expiration_days( $day
 }
 
 // end token submission tweak
+
+// gravityflow_site_cookie_path
+add_filter( 'gravityflow_site_cookie_path', function( $path ) {
+     return '/';
+});


### PR DESCRIPTION
Use patch from Gravity View support to address incomplete links in
reminder emails.