### PR TITLE
Di 1759 Add Nightingale CSS class override for GForm dropdown

### DIFF
--- a/style/forms.scss
+++ b/style/forms.scss
@@ -30,3 +30,12 @@
 	@extend .c-card;
 	@extend .c-card--information;
 }
+
+// Dropdown Css extension for Gravity Forms Ajax compatibility
+.gform_wrapper select {
+  @extend .c-form-dropdown__select;
+}
+
+body .gform_wrapper .top_label div.ginput_container {
+  @extend .c-form-dropdown;
+}


### PR DESCRIPTION
Add a new gravityforms.scss file with css override necessary for drop downs to function with AJAX calls