### PR TITLE
[refs #di-1832] Display child pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -226,3 +226,8 @@ require get_template_directory(). '/inc/gravity-flow.php';
  * Prevent Advanced Custom Fields from disabling standard custom fields.
  */
 require get_template_directory() . '/inc/advanced-custom-fields.php';
+
+/**
+ * Provide shortcode for dispaying child pages within a parent page.
+ */
+require get_template_directory() . '/inc/display-child-pages.php';

--- a/inc/display-child-pages.php
+++ b/inc/display-child-pages.php
@@ -13,4 +13,3 @@ function display_child_pages() {
 	return $childpages;
 }
 add_shortcode('display_child_pages', 'display_child_pages');
-?>

--- a/inc/display-child-pages.php
+++ b/inc/display-child-pages.php
@@ -1,8 +1,8 @@
 <?php
 function display_child_pages() {
 	// use shortcode to display in full all direct child pages of current page
-	global $post;
-	$child_pages = get_pages( array( 'child_of' => $post->ID, 'sort_column' => 'menu_order', 'sort_order' => 'asc' ) );
+	$post_id = get_the_ID();
+	$child_pages = get_pages( array( 'child_of' => $post_id, 'sort_column' => 'menu_order', 'sort_order' => 'asc' ) );
 	foreach ( $child_pages as $child_page ) {
 		$content = $child_page->post_content;
 		$page_title = $child_page->post_title;

--- a/inc/display-child-pages.php
+++ b/inc/display-child-pages.php
@@ -1,0 +1,16 @@
+<?php
+function display_child_pages() {
+	// use shortcode to display in full all direct child pages of current page
+	global $post;
+	$child_pages = get_pages( array( 'child_of' => $post->ID, 'sort_column' => 'menu_order', 'sort_order' => 'asc' ) );
+	foreach ( $child_pages as $child_page ) {
+		$content = $child_page->post_content;
+		$page_title = $child_page->post_title;
+		$page_link = get_page_link( $child_page->ID );
+		$childpages .= '<h3><a href="'.$page_link.'">'.$page_title.'</a></h3>';
+		$childpages .= apply_filters( 'the_content', $child_page->post_content );
+	}
+	return $childpages;
+}
+add_shortcode('display_child_pages', 'display_child_pages');
+?>


### PR DESCRIPTION
This adds a short code so that we can display child pages in full on any parent page.

We need this so that we can use the parent/child structure for cohort information on the corporate website. The idea is that each cohort will have its own child page under the programme's [key-information page](https://www.leadershipacademy.nhs.uk/programmes/rosalind-franklin-programme/key-information/).

At the moment, each cohort is listed as a content block on this page. The problem with this approach is that cohorts are deleted once applications close. Having them as separate pages allows us to keep the information available to applicants after applications close, but with the ability to exclude them from the parent page.

The result on a local test site looks like this:
<img width="613" alt="Screenshot 2020-02-26 at 15 49 58" src="https://user-images.githubusercontent.com/1991226/75361816-cbcdba80-58af-11ea-85d0-86b0eb02abad.png">

We can show/hide pages by using the checkbox provided by the Exclude Pages From Navigation plugin as shown below:
<img width="266" alt="Screenshot 2020-02-26 at 16 00 16" src="https://user-images.githubusercontent.com/1991226/75362835-36332a80-58b1-11ea-89c9-b6a97c091066.png">

And we can control the order that child pages are displayed via the menu order option as shown below:
<img width="266" alt="Screenshot 2020-02-26 at 16 02 09" src="https://user-images.githubusercontent.com/1991226/75363008-6ed30400-58b1-11ea-996c-b4bce6c49aa3.png">
